### PR TITLE
Fixed issue relating to inconsistency with change of isPrivate from the front-end to back-end

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -134,10 +134,22 @@ topicsController.updateIsPrivate = (req, res, next) => __awaiter(void 0, void 0,
             return next();
         }
         // Ensures the parsing of the isPrivate value from req.body
-        const isPrivate = req.body.isPrivate === 'true';
+        const isPrivate = req.body.isPrivate;
+        // This is for testing
+        console.log(isPrivate);
+        let isPrivateStr;
+        // This method only ensures for a 1-time change
+        if (isPrivate === 'true') {
+            isPrivateStr = 'false';
+        }
+        else if (isPrivate === 'false') {
+            isPrivateStr = 'true';
+        }
+        console.log(isPrivateStr);
         // Correct arguments passed to the db setObjectField method, namely through topic id
         // and the boolean isPrivate
-        yield database_1.default.setObjectField('topic:' + tid, 'isPrivate', isPrivate);
+        //
+        yield database_1.default.setObjectField('topic:' + tid, 'isPrivate', isPrivateStr);
         res.status(200).send({ message: 'IsPrivate attribute updated successfully' });
     }
     catch (error) {

--- a/src/controllers/topics.ts
+++ b/src/controllers/topics.ts
@@ -160,10 +160,12 @@ topicsController.updateIsPrivate = async (req: topics, res: topics, next: () => 
         } else if (isPrivate === 'false') {
             isPrivateStr = 'true';
         }
+        // This is for testing
+        console.log(isPrivateStr)
         // Correct arguments passed to the db setObjectField method, namely through topic id
         // and the boolean isPrivate
         //
-        await db.setObjectField('topic:' + tid, 'isPrivate', isPrivate === 'true'); 
+        await db.setObjectField('topic:' + tid, 'isPrivate', isPrivateStr); 
 
         res.status(200).send({ message: 'IsPrivate attribute updated successfully' });
     } catch (error) {


### PR DESCRIPTION
This pull request where the json request from the front-end did not correctly store the isPrivate altered attribute depending on the user input. Thus the src/controllers/topics.ts file was adjusted accordingly to ensure the correct value was sent back to the front-end and updated in the database. This resolves issue #32 .