### PR TITLE
Reverted error that caused inability of user to delete a post in src/privileges/posts.js

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -172,7 +172,7 @@ privsPosts.canDelete = async function (pid, uid) {
     });
     results.isMod = results.isMod[0];
     if (results.isAdmin) {
-        return { flag: false }; //false
+        return { flag: true };
     }
 
     if (!results.isMod && results.isLocked) {
@@ -184,8 +184,8 @@ privsPosts.canDelete = async function (pid, uid) {
         return { flag: false, message: `[[error:post-delete-duration-expired, ${meta.config.postDeleteDuration}]]` };
     }
     const { deleterUid } = postData;
-    const flag = results['posts:delete'] && ((!results.isOwner && (deleterUid === 0 || deleterUid === postData.uid)) || results.isMod);
-    return { flag: flag, message: '[[error:no-privileges]]' }; //false
+    const flag = results['posts:delete'] && ((results.isOwner && (deleterUid === 0 || deleterUid === postData.uid)) || results.isMod);
+    return { flag: flag, message: '[[error:no-privileges]]' };
 };
 
 privsPosts.canFlag = async function (pid, uid) {


### PR DESCRIPTION
This pull request resolves issue #53 . This was done by correcting a conditional statement that was set by default to false when it shouldn't have been, the source file is src/privileges/posts.js. The code was reverted and testing was conducted to ensure post deletion functionality was working. 