### PR TITLE
Implementing back end logic for to add isUrgent to topic through src/topics/create.js

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -35,9 +35,23 @@ module.exports = function (Topics) {
             viewcount: 0,
             isPrivate: false,
             isAnonymous: false,
+            isUrgent: false,
         };
-        topicData.isPrivate = data.isPrivate
-        topicData.isAnonymous = data.isAnonymous
+        // added code for sprint 1
+        // type casting
+        /** 
+         * @type {boolean}
+         */
+        topicData.isPrivate = data.isPrivate;
+        /** 
+         * @type {boolean}
+         */
+        topicData.isAnonymous = data.isAnonymous;
+        // added code for sprint 2
+        /** 
+         * @type {boolean}
+         */
+        topicData.isUrgent = data.isUrgent;
 
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -39,16 +39,16 @@ module.exports = function (Topics) {
         };
         // added code for sprint 1
         // type casting
-        /** 
+        /**
          * @type {boolean}
          */
         topicData.isPrivate = data.isPrivate;
-        /** 
+        /**
          * @type {boolean}
          */
         topicData.isAnonymous = data.isAnonymous;
         // added code for sprint 2
-        /** 
+        /**
          * @type {boolean}
          */
         topicData.isUrgent = data.isUrgent || false;

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -51,7 +51,7 @@ module.exports = function (Topics) {
         /** 
          * @type {boolean}
          */
-        topicData.isUrgent = data.isUrgent;
+        topicData.isUrgent = data.isUrgent || false;
 
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');

--- a/test/topics.js
+++ b/test/topics.js
@@ -416,6 +416,17 @@ describe('Topic\'s', () => {
                 done();
             });
         });
+        // code for testing sprint 2, ensuring the isUrgent attribute
+        // is an attribute of the topic object
+        it('should get the newly added isUrgent field for topic', (done) => {
+            topics.getTopicFields(newTopic.tid, ['isUrgent'], (err, data) => {
+                assert.ifError(err);
+                assert(Object.keys(data).length === 1);
+                assert(data.hasOwnProperty('isUrgent'));
+                done();
+            });
+        });
+        
 
         describe('.getTopicWithPosts', () => {
             let tid;


### PR DESCRIPTION
This pull request resolves #61 . The isUrgent boolean attribute has been added to the topic object through modifying the src/topics/create.js, and automated testing ensured for the presence of the isUrgent attribute. This pull request will ensure for back-end presence of the isUrgent attribute. 