### PR TITLE
Added an if condition that checks if the post is urgent if it is then display the urgent banner

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -24,14 +24,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
 </script>
 
+
+
+     
 <div class="clearfix post-header">
 
+  {{{ if (isUrgent == "true") }}}
   <div style="background-color: red; color: white; text-align: center; padding: 10px; font-size: 20px; font-weight: bold;">
    THIS POST IS URGENT
    <h2 style="text-align: center;">
    ⚠️
 </h2>
 </div>
+
+
+{{{end}}}
+
+
 
 <!-- IF !privileges.isAdminOrMod -->
 


### PR DESCRIPTION
If the post is urgent then the urgent banner should be shown if not then the urgent banner should not be shown. This was completed through adding the proper if condition to the proper place. Exemplified through   {{{ if (isUrgent == "true") }}}. This resolves issue #97. 