### PR TITLE
Resolving error with hegel static tool config and function return error

### DIFF
--- a/.hegelrc
+++ b/.hegelrc
@@ -1,0 +1,4 @@
+include:
+  - ./src/pubsub.ts
+exclude:
+  - ./node_modules/**

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -96,12 +96,12 @@ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.g
 prestart.loadConfig(configFile);
 prestart.versionCheck();
 
-(function() {
-if (!configExists && process.argv[2] !== 'setup') {
-    require('./setup').webInstall();
-    return;
-}
-})();
+(function () {
+    if (!configExists && process.argv[2] !== 'setup') {
+        require('./setup').webInstall();
+    }
+}());
+
 
 process.env.CONFIG = configFile;
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -96,10 +96,12 @@ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.g
 prestart.loadConfig(configFile);
 prestart.versionCheck();
 
+(function() {
 if (!configExists && process.argv[2] !== 'setup') {
     require('./setup').webInstall();
     return;
 }
+})();
 
 process.env.CONFIG = configFile;
 


### PR DESCRIPTION
This involved resolving the issue with the config checking all files, where the config was modified to test only specified files (`.hegelrc`). Another change was made in `src/cli/index.js` because there was a return outside a function, it kept causing errors, to which the return was enclosed with an automatic function call. Resolves #101 .