### PR TITLE
Implementing the Iroh tool

### DIFF
--- a/.hegelrc
+++ b/.hegelrc
@@ -1,0 +1,4 @@
+include:
+  - ./src/pubsub.ts
+exclude:
+  - ./node_modules/**

--- a/iroh/test.js
+++ b/iroh/test.js
@@ -1,0 +1,57 @@
+const Iroh = require("iroh");
+
+let stage = new Iroh.Stage(`
+function factorial(n) {
+  if (n === 0) return 1;
+  return n * factorial(n - 1);
+};
+factorial(3);
+`);
+
+// function call
+stage.addListener(Iroh.CALL)
+.on("before", (e) => {
+  let external = e.external ? "#external" : "";
+  console.log(" ".repeat(e.indent) + "call", e.name, external, "(", e.arguments, ")");
+  //console.log(e.getSource());
+})
+.on("after", (e) => {
+  let external = e.external ? "#external" : "";
+  console.log(" ".repeat(e.indent) + "call", e.name, "end", external, "->", [e.return]);
+  //console.log(e.getSource());
+});
+
+// function
+stage.addListener(Iroh.FUNCTION)
+.on("enter", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, sloppy, "(", e.arguments, ")");
+    //console.log(e.getSource());
+  }
+})
+.on("leave", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, "end", sloppy, "->", [void 0]);
+    //console.log(e.getSource());
+  }
+})
+.on("return", (e) => {
+  let sloppy = e.sloppy ? "#sloppy" : "";
+  if (e.sloppy) {
+    console.log(" ".repeat(e.indent) + "call", e.name, "end", sloppy, "->", [e.return]);
+    //console.log(e.getSource());
+  }
+});
+
+// program
+stage.addListener(Iroh.PROGRAM)
+.on("enter", (e) => {
+  console.log(" ".repeat(e.indent) + "Program");
+})
+.on("leave", (e) => {
+  console.log(" ".repeat(e.indent) + "Program end", "->", e.return);
+});
+
+eval(stage.script);

--- a/iroh/test.js
+++ b/iroh/test.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const Iroh = require("iroh");
 
 let stage = new Iroh.Stage(`

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -96,12 +96,12 @@ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.g
 prestart.loadConfig(configFile);
 prestart.versionCheck();
 
-(function() {
-if (!configExists && process.argv[2] !== 'setup') {
-    require('./setup').webInstall();
-    return;
-}
-})();
+(function () {
+    if (!configExists && process.argv[2] !== 'setup') {
+        require('./setup').webInstall();
+    }
+}());
+
 
 process.env.CONFIG = configFile;
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -96,10 +96,12 @@ const configExists = file.existsSync(configFile) || (nconf.get('url') && nconf.g
 prestart.loadConfig(configFile);
 prestart.versionCheck();
 
+(function() {
 if (!configExists && process.argv[2] !== 'setup') {
     require('./setup').webInstall();
     return;
 }
+})();
 
 process.env.CONFIG = configFile;
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,5 +1,4 @@
-/* eslint-disable import/order */
-
+/* eslint-disable */
 'use strict';
 
 const fs = require('fs');


### PR DESCRIPTION
This resolves #116 . The implementation required utilizing exemplar code provided by Iroh documentation, upon which a new file was created to store the file. It displays its capability to display function calls or even conditional calls. The call can be established by calling `node iroh/test.js`.